### PR TITLE
Fix menu #61

### DIFF
--- a/src/components/Common/Nav/Nav.style.js
+++ b/src/components/Common/Nav/Nav.style.js
@@ -2,9 +2,10 @@ import styled from 'styled-components';
 import { NavLink } from 'react-router-dom';
 import { breakpointsMax } from '../../../constants/breakpoints';
 
-export const Header = styled.header`
+export const Header = styled.header.attrs({
+  className: 'z-max',
+})`
   width: 100vw;
-  z-index: 998;
   border-bottom: 1px solid #386a9b;
   height: 3rem;
   display: flex;

--- a/src/components/Legend/Legend.styles.js
+++ b/src/components/Legend/Legend.styles.js
@@ -18,7 +18,7 @@ function rotationBuilder() {
 }
 
 export const LegendUseclass = styled.div.attrs({
-  className: 'fixed left-0 bottom-0 z-max',
+  className: 'fixed left-0 bottom-0 z-9999',
 })``;
 
 export const Circle = styled.div.attrs({

--- a/src/components/Map/Map.css
+++ b/src/components/Map/Map.css
@@ -11,7 +11,7 @@
 .leaflet-control-zoom {
   position: fixed;
   top: 52px;
-  right: 8px;
+  right: 14px;
 }
 
 /* Scroll Bar CSS */


### PR DESCRIPTION
Fixed - it's necessary to use the Tachyons classes for z-index rather than defining in the styled component, otherwise an element using Tachyons classes will still appear above it. You can use the `attrs()` method on styled components like this:

```
const myElement = styled.div.attrs({
  className: "z-max"
})`
 margin: 0;
 left: 0;
`